### PR TITLE
aオプション追加

### DIFF
--- a/05.ls/ls_command_1.rb
+++ b/05.ls/ls_command_1.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 # !/usr/bin/envruby
-
-directory = Dir.glob('*')
 MAX_CLUMN = 3
+require 'optparse'
+params = ARGV.getopts('a')
+directory = params['a'] ? Dir.glob('*', File::FNM_DOTMATCH) : Dir.glob('*')
+
 MAXIMUM_FILE = directory.length.to_f
 row = (MAXIMUM_FILE / MAX_CLUMN).ceil
 if (MAX_CLUMN % MAXIMUM_FILE) != 0


### PR DESCRIPTION
# lsコマンド aオプション追加

- aオプションの追加

## 追記事項
- rubocop通しています
- 隠しファイルが通常のlsコマンドのaオプションの通りに表示できてないです、
調べても分からなかったので一度提出します
