### PR TITLE
wcコマンド作成

### DIFF
--- a/06.wc/ls.rb
+++ b/06.wc/ls.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+# !/usr/bin/envruby
+
+require 'optparse'
+require 'etc'
+
+MAX_CLUMN = 3
+
+FILE_TYPE = { 'fifo' => 'p',
+              'characterSpecial' => 'c',
+              'directory' => 'd',
+              'blockSpecial' => 'b',
+              'file' => '-',
+              'link' => 'l',
+              'socket' => 's' }.freeze
+
+ACCESS_PERMISSION = { 0 => '---',
+                      1 => '--x',
+                      2 => '-w-',
+                      3 => '-wx',
+                      4 => 'r--',
+                      5 => 'r-x',
+                      6 => 'rw-',
+                      7 => 'rwx' }.freeze
+
+def main
+  params = ARGV.getopts('arl')
+  dirs = ls_command(params)
+  output_files(params, dirs)
+end
+
+def ls_command(params)
+  ls_option = params['a'] ? Dir.glob('*', File::FNM_DOTMATCH) : Dir.glob('*')
+  params['r'] ? ls_option.reverse : ls_option
+end
+
+def output_files(params, dirs)
+  params['l'] ? command_l(dirs) : show_directories(dirs)
+end
+
+def show_directories(dirs)
+  maxium_file = dirs.length.to_f
+  row = (maxium_file / MAX_CLUMN).ceil
+  if (MAX_CLUMN % maxium_file) != 0
+    ((MAX_CLUMN * row) - maxium_file).to_i.times do
+      dirs.push(nil)
+    end
+  end
+  file_list = dirs.each_slice(row).to_a
+  longest_name = dirs.compact.max_by(&:size)
+  padding = 15
+  files_list = file_list.transpose
+  files_list.each do |list|
+    list.each do |l|
+      print l.to_s.ljust(longest_name.size + padding)
+    end
+    print "\n"
+  end
+end
+
+def total_file(dirs)
+  total_file_blocks = dirs.map { |dir| File.stat(dir).blocks }
+  puts "total #{total_file_blocks.sum}"
+end
+
+def command_l(dirs)
+  dirs.each do |dir|
+    fs = File::Stat.new(dir)
+    link = fs.nlink.to_s
+    user_id = fs.uid
+    user_name = Etc.getpwuid(user_id).name
+    group_id = fs.gid
+    group_name = Etc.getgrgid(group_id).name
+    byte = fs.size.to_s
+    files = fs.mode.digits(8).take(3).reverse
+    print (FILE_TYPE[fs.ftype]).to_s + ACCESS_PERMISSION[files[0]] + ACCESS_PERMISSION[files[1]] + ACCESS_PERMISSION[files[2]]
+    puts "#{link.rjust(2)} #{user_name} #{group_name} #{byte.rjust(4)}  #{fs.mtime.strftime('%_m %e %H:%M')} #{dir}"
+  end
+end
+main

--- a/06.wc/wc.rb
+++ b/06.wc/wc.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'optparse'
+
+def main
+  params = ARGV.getopts('l')
+  files_data = take_files
+  total_files = sum_files(files_data)
+  files_data.empty? ? basic_input(params) : type_l_command(params, files_data, total_files)
+end
+
+def basic_input(params)
+  standard_input = $stdin.read
+  print standard_input.count("\n").to_s.rjust(8).to_s
+  puts "#{standard_input.split(/\s+/).size.to_s.rjust(8)}#{standard_input.bytesize.to_s.rjust(7)}" unless params['l']
+  print "\n"
+end
+
+def take_files
+  files_data = []
+  ARGV.each do |information|
+    read_file = File.read(information)
+    file_data = {
+      line: read_file.count("\n"),
+      word: read_file.split(/\s+/).size,
+      byte: read_file.bytesize,
+      filename: File.basename(information)
+    }
+    files_data << file_data
+  end
+  files_data
+end
+
+def sum_files(files_data)
+  total_files = {
+    total_line: files_data.sum { |lines| lines[:line] },
+    total_word: files_data.sum { |words| words[:word] },
+    total_byte: files_data.sum { |bytes| bytes[:byte] }
+  }
+end
+
+def type_l_command(params, files_data, total_files)
+  params['l'] ? show_lines(files_data, total_files) : show_files(files_data, total_files)
+end
+
+def show_files(files_data, total_files)
+  files_data.each do |file|
+    puts "#{file[:line].to_s.rjust(8)} #{file[:word].to_s.rjust(7)} #{file[:byte].to_s.rjust(7)} #{file[:filename]}"
+  end
+  unless files_data.size == 1
+    puts "#{total_files[:total_line].to_s.rjust(8)} #{total_files[:total_word].to_s.rjust(7)} #{total_files[:total_byte].to_s.rjust(7)} total"
+  end
+end
+
+def show_lines(files_data, total_files)
+  files_data.each do |file|
+    puts "#{file[:line].to_s.rjust(8)} #{file[:filename]}"
+  end
+  puts "#{total_files[:total_line].to_s.rjust(8)} total" unless files_data.size == 1
+end
+
+main

--- a/06.wc/wc.rb
+++ b/06.wc/wc.rb
@@ -47,7 +47,7 @@ def show_files(files_data, total_files)
   files_data.each do |file|
     puts "#{file[:line].to_s.rjust(8)} #{file[:word].to_s.rjust(7)} #{file[:byte].to_s.rjust(7)} #{file[:filename]}"
   end
-  unless files_data.size == 1
+  if files_data.size != 1
     puts "#{total_files[:total_line].to_s.rjust(8)} #{total_files[:total_word].to_s.rjust(7)} #{total_files[:total_byte].to_s.rjust(7)} total"
   end
 end


### PR DESCRIPTION
### wcコマンド作成

### 作成条件
- lオプション実装
- 標準入力からも受け取れる
- 引数にファイル名が複数個来た場合にも対応
- 自作のls -lコマンドと自作のwcコマンドをつなげた

### 追記事項
`rubocop`2点通せてないです。 